### PR TITLE
Check open file's project root first

### DIFF
--- a/utils/getPackageDir.js
+++ b/utils/getPackageDir.js
@@ -6,14 +6,14 @@ const PACKAGE_JSON_FILENAME = "package.json";
 
 function getPackageDir () {
     // Check active file's project root first
-    var editor = atom.workspace.getActivePaneItem();
-    if (editor) {
-        var file = editor.buffer.file;
-        if (file) {
-            var filepath = file.path;
+    const editor = atom.workspace.getActivePaneItem();
+    if ( editor ) {
+        const file = editor.buffer.file;
+        if ( file ) {
+            const filepath = file.path;
             pathinfo = atom.project.relativizePath(filepath);
             jsonpath = join(pathinfo[0], PACKAGE_JSON_FILENAME);
-            if (isPackageJson(jsonpath)) {
+            if ( isPackageJson(jsonpath) ) {
                 return pathinfo[0];
             }
         }

--- a/utils/getPackageDir.js
+++ b/utils/getPackageDir.js
@@ -12,7 +12,10 @@ function getPackageDir () {
         if (file) {
             var filepath = file.path;
             pathinfo = atom.project.relativizePath(filepath);
-            return pathinfo[0];
+            jsonpath = join(pathinfo[0], PACKAGE_JSON_FILENAME);
+            if (isPackageJson(jsonpath)) {
+                return pathinfo[0];
+            }
         }
     }
 

--- a/utils/getPackageDir.js
+++ b/utils/getPackageDir.js
@@ -5,6 +5,17 @@ import isPackageJson from "./isPackageJson";
 const PACKAGE_JSON_FILENAME = "package.json";
 
 function getPackageDir () {
+    // Check active file's project root first
+    var editor = atom.workspace.getActivePaneItem();
+    if (editor) {
+        var file = editor.buffer.file;
+        if (file) {
+            var filepath = file.path;
+            pathinfo = atom.project.relativizePath(filepath);
+            return pathinfo[0];
+        }
+    }
+
     const projectPaths = atom.project.getPaths();
 
     for ( path of projectPaths ) {


### PR DESCRIPTION
Atom.io supports opening multiple project folders at once via File -> Add Project Folder...

Previously, npm-plus searched the list of all paths for the first package.json file to determine the context in which to run npm commands. This may not be the desired behavior if the user is editing multiple projects that have package.json files.

Now, the project root of the currently active file will be checked first. If it doesn't have a package.json file, then the previous behavior is used.